### PR TITLE
Go Mod Added

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module local/build
+
+go 1.14
+
+require (
+	github.com/apache/thrift v0.13.0 // indirect
+	github.com/hazelcast/hazelcast-go-client v0.6.0
+	github.com/stretchr/testify v1.5.1 // indirect
+)


### PR DESCRIPTION
Go mod will be used for handling multiple hazelcast client versions and running them with the same code block on every branch.
for e.g. (go mod tidy && go run client.py)