### PR TITLE
HZC-521 - Regular printing of progress

### DIFF
--- a/client.go
+++ b/client.go
@@ -40,10 +40,12 @@ func main() {
 		log.Println("Connection Successful!")
 		log.Println("Now, `map` will be filled with random entries.")
 		rand.Seed(time.Now().UTC().UnixNano())
-		for true {
-			randKey := rand.Intn(100000)
-			mp.Put("key"+string(randKey), "value"+string(randKey))
-			if randKey%10 == 0 {
+		iterationCounter := 0
+		for {
+			randKey := string(rune(rand.Intn(100000)))
+			mp.Put("key" + randKey, "value" + randKey)
+			if iterationCounter++; iterationCounter == 10 {
+				iterationCounter = 0
 				size, _ := mp.Size()
 				log.Println(fmt.Sprintf("Map size: %d", size))
 			}

--- a/client_with_ssl.go
+++ b/client_with_ssl.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"math/rand"
-	"path/filepath"
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/config"
 	"github.com/hazelcast/hazelcast-go-client/config/property"
+	"log"
+	"math/rand"
+	"path/filepath"
 	"time"
 )
 
@@ -48,10 +48,12 @@ import (
 		log.Println("Connection Successful!")
 		log.Println("Now, `map` will be filled with random entries.")
 		rand.Seed(time.Now().UTC().UnixNano())
-		for true {
-			randKey := rand.Intn(100000)
-			mp.Put("key"+string(randKey), "value"+string(randKey))
-			if randKey%10 == 0 {
+		iterationCounter := 0
+		for {
+			randKey := string(rune(rand.Intn(100000)))
+			mp.Put("key" + randKey, "value" + randKey)
+			if iterationCounter++; iterationCounter == 10 {
+				iterationCounter = 0
 				size, _ := mp.Size()
 				log.Println(fmt.Sprintf("Map size: %d", size))
 			}


### PR DESCRIPTION
As discussed with @huseyinbabal , here is the test result:

```java
        client, _ := hazelcast.NewClientWithConfig(cfg)

	mp, _ := client.GetMap("map")
	mp.Put("key", "value")
	val, _ := mp.Get("key")
	if val == "value" {
		log.Println("Connection Successful!")
		log.Println("Now, `map` will be filled with random entries.")
		rand.Seed(time.Now().UTC().UnixNano())
		iterationCounter := 0
		for {
			randKey := string(rune(rand.Intn(100000)))
			mp.Put("key" + randKey, "value" + randKey)
			if iterationCounter++; iterationCounter == 10 {
				iterationCounter = 0
				size, _ := mp.Size()
				log.Println(fmt.Sprintf("Map size: %d", size))
			}
		}
	}
```

```
2021/05/20 14:27:56 github.com/hazelcast/hazelcast-go-client/internal.(*clusterService).logMembers
INFO: hz.client_1 [test-01] [0.5-SNAPSHOT] 

Members {size:1} [
        Member 100.119.172.240:30793 - 740e7ad1-04e9-4a24-ab22-d47e4e4b8d7f
]

2021/05/20 14:27:56 github.com/hazelcast/hazelcast-go-client/internal.(*clusterService).initMembershipListener
INFO: hz.client_1 [test-01] [0.5-SNAPSHOT] Registered membership listener with ID 860db3ae-668f-4fde-a9e4-3a4a3ed5f72a
2021/05/20 14:27:56 github.com/hazelcast/hazelcast-go-client/internal.(*lifecycleService).fireLifecycleEvent
INFO: hz.client_1 [test-01] [0.5-SNAPSHOT] HazelcastClient 0.5-SNAPSHOT is CONNECTED
2021/05/20 14:27:56 github.com/hazelcast/hazelcast-go-client/internal.(*statistics).start
INFO: hz.client_1 [test-01] [0.5-SNAPSHOT] Client statistics is enabled with period  1s
2021/05/20 14:27:56 github.com/hazelcast/hazelcast-go-client/internal.(*lifecycleService).fireLifecycleEvent
INFO: hz.client_1 [test-01] [0.5-SNAPSHOT] HazelcastClient 0.5-SNAPSHOT is STARTED
2021/05/20 14:27:57 Connection Successful!
2021/05/20 14:27:57 Now, `map` will be filled with random entries.
2021/05/20 14:27:59 Map size: 5973
2021/05/20 14:28:01 Map size: 5983
2021/05/20 14:28:04 Map size: 5993
2021/05/20 14:28:06 Map size: 6003
2021/05/20 14:28:08 Map size: 6013
2021/05/20 14:28:10 Map size: 6023
2021/05/20 14:28:12 Map size: 6032
2021/05/20 14:28:14 Map size: 6041
2021/05/20 14:28:16 Map size: 6050

```