### PR TITLE
HZC-3278: Rollback the HZ_CLOUD_COORDINATOR_BASE_URL setting removal

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/types"
 	"log"
 	"math/rand"
+	"os"
 	"time"
 )
 
@@ -17,6 +18,7 @@ import (
 //
 // See: https://docs.hazelcast.com/cloud/go-client
 func main() {
+	_ = os.Setenv("HZ_CLOUD_COORDINATOR_BASE_URL", "YOUR_DISCOVERY_URL")
 	ctx := context.Background()
 	config := hazelcast.NewConfig()
 	config.Cluster.Name = "YOUR_CLUSTER_NAME"

--- a/client_with_ssl.go
+++ b/client_with_ssl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hazelcast/hazelcast-go-client/types"
 	"log"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"time"
 )
@@ -19,6 +20,7 @@ import (
 //
 // See: https://docs.hazelcast.cloud/docs/go-client
 func main() {
+	_ = os.Setenv("HZ_CLOUD_COORDINATOR_BASE_URL", "YOUR_DISCOVERY_URL")
 	ctx := context.Background()
 	config := hazelcast.NewConfig()
 	config.Cluster.Name = "YOUR_CLUSTER_NAME"


### PR DESCRIPTION
```
> go mod tidy && go run client_with_ssl.go
2022/08/08 14:26:21 INFO : trying to connect to cluster: ba-46890
2022/08/08 14:26:23 INFO : connected to cluster: ba-46890
2022/08/08 14:26:23 INFO :

Members {size:1, ver:1} [
	Member 10.7.213.76:30000 - dad83373-4219-4f43-97f0-222085e22f99
]

Connection Successful!
'cities' map now contains 8 entries.
```